### PR TITLE
Simplify and optimize structs

### DIFF
--- a/2DProceduralLinesMap/Assets/ccglp/Procedural2DMap/Line.cs
+++ b/2DProceduralLinesMap/Assets/ccglp/Procedural2DMap/Line.cs
@@ -1,10 +1,8 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace ccglp.Procedural
 {
-    public class Line
+    public readonly struct Line
     {
         public enum LineType
         {
@@ -13,10 +11,9 @@ namespace ccglp.Procedural
             VERTICAL
         }
 
-        private LineType type;
-        private float nodeSize;
-        private PositivePoint worldSize, startPoint;
-
+        private readonly LineType type;
+        private readonly float nodeSize;
+        private readonly PositivePoint worldSize, startPoint;
 
         public Line(PositivePoint startPoint, LineType type, float nodeSize, PositivePoint worldSize)
         {
@@ -27,32 +24,18 @@ namespace ccglp.Procedural
         }
 
         public Vector2 GetWorldStartPoint()
-        {
-            Vector2 aux = new Vector2();
-
-            aux.x = startPoint.x < (worldSize.x * 0.5f) ? (startPoint.x - (worldSize.x) * 0.5f) * nodeSize : (startPoint.x - (worldSize.x) * 0.5f) * nodeSize;
-            aux.y = startPoint.y < (worldSize.y * 0.5f) ? (startPoint.y - (worldSize.y) * 0.5f) * -nodeSize : -(startPoint.y - (worldSize.y) * 0.5f) * nodeSize;
-            return aux;
-
-
-        }
-
-
+            => new Vector2
+            {
+                x = (startPoint.x - worldSize.x * 0.5f) * nodeSize,
+                y = (startPoint.y < worldSize.y * 0.5f)
+                    ? +(startPoint.y - worldSize.y * 0.5f) * -nodeSize
+                    : -(startPoint.y - worldSize.y * 0.5f) * +nodeSize,
+            };
 
         public LineType Type
-        {
-            get
-            {
-                return type;
-            }
-        }
+            => type;
 
         public PositivePoint StartPoint
-        {
-            get
-            {
-                return startPoint;
-            }
-        }
+            => startPoint;
     }
 }

--- a/2DProceduralLinesMap/Assets/ccglp/Procedural2DMap/MapSpecifications.cs
+++ b/2DProceduralLinesMap/Assets/ccglp/Procedural2DMap/MapSpecifications.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace ccglp.Procedural
 {
@@ -18,27 +16,12 @@ namespace ccglp.Procedural
         }
 
         public uint BranchLongitude
-        {
-            get
-            {
-                return branchLongitude;
-            }
-        }
+            => branchLongitude;
 
         public uint BranchQuantity
-        {
-            get
-            {
-                return branchQuantity;
-            }
-        }
+            => branchQuantity;
 
         public uint NumberOfLines
-        {
-            get
-            {
-                return numberOfLines;
-            }
-        }
+            => numberOfLines;
     }
 }

--- a/2DProceduralLinesMap/Assets/ccglp/Procedural2DMap/PositivePoint.cs
+++ b/2DProceduralLinesMap/Assets/ccglp/Procedural2DMap/PositivePoint.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-
-namespace ccglp.Procedural
+﻿namespace ccglp.Procedural
 {
 
     [System.Serializable]

--- a/2DProceduralLinesMap/Assets/ccglp/Procedural2DMap/ProceduralMap.cs
+++ b/2DProceduralLinesMap/Assets/ccglp/Procedural2DMap/ProceduralMap.cs
@@ -213,7 +213,7 @@ namespace ccglp.Procedural
         }
 
 
-        private void GenerateBranch(Line line)
+        private void GenerateBranch(in Line line)
         {
 
             if (Random.Range(0, 100) <= 50)
@@ -226,7 +226,7 @@ namespace ccglp.Procedural
             }
         }
 
-        private void GenerateBranchUpRight(Line line)
+        private void GenerateBranchUpRight(in Line line)
         {
             int branchIterations = 0;
             PositivePoint pos = GetBranchStartPoint(line);
@@ -246,7 +246,7 @@ namespace ccglp.Procedural
             }
         }
 
-        private void GenerateBranchDownLeft(Line line)
+        private void GenerateBranchDownLeft(in Line line)
         {
             int branchIterations = 0;
             PositivePoint pos = GetBranchStartPoint(line);
@@ -267,7 +267,7 @@ namespace ccglp.Procedural
             }
         }
 
-        private PositivePoint GetBranchStartPoint(Line line)
+        private PositivePoint GetBranchStartPoint(in Line line)
         {
             PositivePoint result = new PositivePoint(0, 0);
             switch (line.Type)


### PR DESCRIPTION
Hey, I cleaned up the code a little.

- Changed `Line` from class to readonly struct to reduce GC (lines are now passed around by readonly reference)
- Removed unnecessary branch in `Line.GetWorldStartPoint` 
- Removed unused namespace imports
- Simplified getters using expression-bodied members